### PR TITLE
Fix compatibility with pytorch from pytorch channel

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ outputs:
         - numpy                                                # [build_platform != target_platform]
         - python                                               # [build_platform != target_platform]
         - pytorch                                              # [build_platform != target_platform]
-        - pytorch ={{ pytorch }}={{ torch_proc_type }}*        # [build_platform != target_platform]
+        - pytorch ={{ pytorch }}=*{{ torch_proc_type }}*       # [build_platform != target_platform]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         # this adds matching cuda requirement to run deps using __cuda package
@@ -56,7 +56,7 @@ outputs:
         - py-opencv
         - python
         - pytorch
-        - pytorch ={{ pytorch }}={{ torch_proc_type }}*
+        - pytorch ={{ pytorch }}=*{{ torch_proc_type }}*
         - requests
         - setuptools
         - six
@@ -74,7 +74,7 @@ outputs:
         - typing_extensions
         - yapf
       run_constrained:
-        - pytorch =*={{ torch_proc_type }}*
+        - pytorch =*=*{{ torch_proc_type }}*
 
     test:
       requires:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Attempt to fix dependency specification so that `mmcv-full` can be installed alongside pytorch from the pytorch channel (instead of just the conda-forge channel).

The main modification is to change `={{ pytorch }}={{ torch_proc_type }}*` to `={{ pytorch }}=*{{ torch_proc_type }}*` (note the extra asterisk).

FIxes #15.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
