### PR TITLE
Fix broken pytorch version constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ outputs:
         - psutil
         - python                                         # [build_platform != target_platform]
         - pytorch                                        # [build_platform != target_platform]
-        - pytorch ={{ pytorch }}={{ torch_proc_type }}*  # [build_platform != target_platform]
+        - pytorch ={{ pytorch }}=*{{ torch_proc_type }}*  # [build_platform != target_platform]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         # this adds matching cuda requirement to run deps using __cuda package
@@ -52,7 +52,7 @@ outputs:
         - pip
         - python
         - pytorch
-        - pytorch ={{ pytorch }}={{ torch_proc_type }}*
+        - pytorch ={{ pytorch }}=*{{ torch_proc_type }}*
         {% if cuda_major >= 12 %}
         - libcublas-dev
         - libcusolver-dev
@@ -72,7 +72,7 @@ outputs:
       run_constrained:
         # additional run constraint to the one from the (version-only) run_export;
         # constraining the CPU builds to CPU pytorch isn't 100% necessary, but cleaner
-        - pytorch =*={{ torch_proc_type }}*
+        - pytorch =*=*{{ torch_proc_type }}*
     test:
       requires:
         - onnx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.1.0" %}
-{% set number = 3 %}  # build number
+{% set number = 4 %}  # build number
 # see https://github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
 {% set torch_proc_type = "cuda" if cuda_compiler_version != "None" else "cpu" %}
 {% if cuda_compiler_version != "None" %}


### PR DESCRIPTION
When trying to install mmcv from conda-forge alongside a precise version of pytorch, the constraint on pytorch's build string fails erroneously due to a missing leading asterisk in the run requirements/constraints. Installation combinations that should be allowed are blocked.

Example repro using micromamba (also repros with bare conda, but it's so slow):
```
micromamba env create -n foobar
conda activate /home/$USER/micromamba/envs/foobar
CONDA_OVERRIDE_CUDA=12.1 \
    micromamba/bin/micromamba install \
    -c conda-forge \
    -c pytorch  \
    -c nvidia \
    pytorch=2.1.0=py3.10_cuda12.1_cudnn8.9.2_0 \
    mmcv=*=*cuda*
```
(Side note: CONDA_OVERRIDE_CUDA is required since the meta.yaml places a requirement that the host has a system cuda installation available, which is not necessary, but that's a different issue.)
    
Result:
```
error    libmamba Could not solve for environment specs
    The following packages are incompatible
    ├─ mmcv * *cuda* is installable and it requires
    │  └─ pytorch * cuda*, which can be installed;
    └─ pytorch 2.1.0 py3.10_cuda12.1_cudnn8.9.2_0 is not installable because it conflicts with any installable versions previously reported.
```
There is a constraint that the build begins with the string literal "cuda" (with nothing before it). However, pytorch builds are prefixed with the python version, followed by the cuda version. So the constraint should be `pytorch * *cuda*`.

I encountered this exact issue with pytorch3d's feedstock repo and applied the same fix in this PR:
https://github.com/conda-forge/pytorch3d-feedstock/pull/9

This issue may be rather common among other feedstock repos.